### PR TITLE
feat: add animated hero section

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -2,16 +2,25 @@ import { useEffect, useState } from 'react';
 
 function Hero() {
   const [offsetY, setOffsetY] = useState(0);
+  const [animate, setAnimate] = useState(false);
 
   useEffect(() => {
     const handleScroll = () => setOffsetY(window.pageYOffset);
     window.addEventListener('scroll', handleScroll);
+    setAnimate(true);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
   return (
-    <section id="hero" style={{ transform: `translateY(${offsetY * 0.2}px)` }}>
-      <h1>Techno Tech</h1>
+    <section
+      id="hero"
+      style={{ transform: `translateY(${offsetY * 0.2}px)` }}
+    >
+      <div className={animate ? 'fade-in' : ''}>
+        <h1>Techno Tech</h1>
+        <p>Innovative solutions for a digital world</p>
+        <button>Get Started</button>
+      </div>
     </section>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -14,3 +14,51 @@ section {
   align-items: center;
   justify-content: center;
 }
+
+#hero {
+  background: linear-gradient(135deg, #000, #333);
+  color: #fff;
+  text-align: center;
+  flex-direction: column;
+}
+
+#hero h1 {
+  font-size: 4rem;
+  margin: 0;
+}
+
+#hero p {
+  font-size: 1.5rem;
+  margin: 1rem 0;
+}
+
+#hero button {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #ff6600;
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+#hero button:hover {
+  background-color: #e65c00;
+}
+
+.fade-in {
+  opacity: 0;
+  animation: fadeInUp 1s ease-out forwards;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Summary
- add hero section with heading, tagline, and button
- style hero with dark gradient and fade-in animation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893c3415b94832fae0c185ea90fc0c4